### PR TITLE
Added check for NETCoreSdkPortableRuntimeIdentifier

### DIFF
--- a/src/typstsharp/typstsharp.csproj
+++ b/src/typstsharp/typstsharp.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <HostRustRuntime Condition="'$(HostRustRuntime)' == '' and '$(NETCoreSdkPortableRuntimeIdentifier)' != ''">$(NETCoreSdkPortableRuntimeIdentifier)</HostRustRuntime>
     <HostRustRuntime Condition="'$(HostRustRuntime)' == '' and '$(NETCoreSdkRuntimeIdentifier)' != ''">$(NETCoreSdkRuntimeIdentifier)</HostRustRuntime>
     <HostRustRuntime Condition="'$(HostRustRuntime)' == ''">win-x64</HostRustRuntime>
     <DefaultRustTargets>linux-x64;win-x64;win-arm64</DefaultRustTargets>


### PR DESCRIPTION
This fixes issue #18. Added an additional check for the `NETCoreSdkPortableRuntimeIdentifier` first, keeping the fallback of checking for `NETCoreSdkRuntimeIdentifier` if the portable one is not found for some reason.