### PR TITLE
Fixes #15 - Include usable error location in error message

### DIFF
--- a/src/typst_core/src/lib.rs
+++ b/src/typst_core/src/lib.rs
@@ -10,6 +10,7 @@ mod world;
 use ecow::EcoString;
 use typst::diag::{SourceDiagnostic, StrResult, Warned};
 use typst::foundations::Dict;
+use typst::{World, WorldExt};
 use typst_layout::PagedDocument;
 use world::SystemWorld;
 
@@ -165,15 +166,58 @@ pub extern "C" fn set_sys_inputs(compiler: *mut Compiler, sys_inputs: *const c_c
 }
 
 fn compile_inner(
-    world: &mut SystemWorld,
+    world: &mut Compiler,
     format: &str,
     ppi: f32,
     standards: &[typst_pdf::PdfStandard],
 ) -> StrResult<(Vec<Vec<u8>>, Vec<SourceDiagnostic>)> {
-    world.reset_time();
-    let (document, warnings) = match typst::compile::<PagedDocument>(world) {
+    world.0.reset_time();
+    let (document, warnings) = match typst::compile::<PagedDocument>(&world.0) {
         Warned { output, warnings } => {
-            let doc = output.map_err(|errors| EcoString::from(format!("{:?}", errors)))?;
+            let doc = output.map_err(|errors| {
+                let message = errors
+                    .iter()
+                    .map(|error| {
+                        let location = error.span.id().and_then(|id| {
+                            let source = world.0.source(id).ok()?;
+                            let range = world.0.range(error.span)?;
+                            let (line, column) =
+                                source.lines().byte_to_line_column(range.start)?;
+                            let text = source.text().get(range.clone())?.to_string();
+
+                            Some(format!(
+                                "line {}, column {}: `{}`",
+                                line + 1,
+                                column + 1,
+                                text
+                            ))
+                        });
+
+                        let hints = error
+                            .hints
+                            .iter()
+                            .map(|hint| hint.v.as_str())
+                            .collect::<Vec<_>>()
+                            .join("; ");
+
+                        match (location, hints.is_empty()) {
+                            (Some(location), false) => {
+                                format!("{} ({}; hint: {})", error.message, location, hints)
+                            }
+                            (Some(location), true) => {
+                                format!("{} ({})", error.message, location)
+                            }
+                            (None, false) => {
+                                format!("{} (hint: {})", error.message, hints)
+                            }
+                            (None, true) => error.message.to_string(),
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                EcoString::from(message)
+            })?;
             (doc, warnings.to_vec())
         }
     };
@@ -241,7 +285,7 @@ pub extern "C" fn compile(
         }
     }
 
-    match compile_inner(&mut compiler.0, format_str, ppi, &standards) {
+    match compile_inner(&mut *compiler, format_str, ppi, &standards) {
         Ok((buffers, warnings)) => {
             let mut c_buffers: Vec<Buffer> = buffers
                 .into_iter()

--- a/src/typst_core/src/lib.rs
+++ b/src/typst_core/src/lib.rs
@@ -166,21 +166,21 @@ pub extern "C" fn set_sys_inputs(compiler: *mut Compiler, sys_inputs: *const c_c
 }
 
 fn compile_inner(
-    world: &mut Compiler,
+    world: &mut SystemWorld,
     format: &str,
     ppi: f32,
     standards: &[typst_pdf::PdfStandard],
 ) -> StrResult<(Vec<Vec<u8>>, Vec<SourceDiagnostic>)> {
-    world.0.reset_time();
-    let (document, warnings) = match typst::compile::<PagedDocument>(&world.0) {
+    world.reset_time();
+    let (document, warnings) = match typst::compile::<PagedDocument>(world) {
         Warned { output, warnings } => {
             let doc = output.map_err(|errors| {
                 let message = errors
                     .iter()
                     .map(|error| {
                         let location = error.span.id().and_then(|id| {
-                            let source = world.0.source(id).ok()?;
-                            let range = world.0.range(error.span)?;
+                            let source = world.source(id).ok()?;
+                            let range = world.range(error.span)?;
                             let (line, column) =
                                 source.lines().byte_to_line_column(range.start)?;
                             let text = source.text().get(range.clone())?.to_string();
@@ -285,7 +285,7 @@ pub extern "C" fn compile(
         }
     }
 
-    match compile_inner(&mut *compiler, format_str, ppi, &standards) {
+    match compile_inner(&mut compiler.0, format_str, ppi, &standards) {
         Ok((buffers, warnings)) => {
             let mut c_buffers: Vec<Buffer> = buffers
                 .into_iter()

--- a/src/typst_core/tests/compile.rs
+++ b/src/typst_core/tests/compile.rs
@@ -1,0 +1,78 @@
+use std::ffi::{c_char, CStr, CString};
+
+use typst_core::{compile, create_compiler, free_compile_result, free_compiler};
+
+#[test]
+fn invalid_single_line_string_produces_an_error() {
+    let root = CString::new(".").unwrap();
+    let source = CString::new("This is not a valid document: # what?").unwrap();
+    let sys_inputs = CString::new("{}").unwrap();
+
+    let compiler = create_compiler(
+        root.as_ptr(),
+        std::ptr::null(),
+        source.as_ptr(),
+        std::ptr::null::<*const c_char>(),
+        0,
+        std::ptr::null(),
+        sys_inputs.as_ptr(),
+        true,
+    );
+    assert!(!compiler.is_null(), "failed to create compiler");
+
+    let result = compile(compiler, std::ptr::null(), 96.0, std::ptr::null());
+    assert!(!result.error.is_null(), "invalid document compiled without an error");
+
+    let error = unsafe { CStr::from_ptr(result.error).to_string_lossy().into_owned() };
+    dbg!(&error);
+
+    free_compile_result(result);
+    free_compiler(compiler);
+
+    assert!(
+        error.contains("expected expression"),
+        "unexpected compiler error: {error}"
+    );
+}
+
+#[test]
+fn invalid_multi_line_string_produces_multiple_errors() {
+    let raw_source = r##"This is not a valid document: # what?
+
+    As a test - this should be able to have a second error, as you can't use dollars here: $50"##;
+
+    let root = CString::new(".").unwrap();
+    let source = CString::new(raw_source).unwrap();
+    let sys_inputs = CString::new("{}").unwrap();
+
+    let compiler = create_compiler(
+        root.as_ptr(),
+        std::ptr::null(),
+        source.as_ptr(),
+        std::ptr::null::<*const c_char>(),
+        0,
+        std::ptr::null(),
+        sys_inputs.as_ptr(),
+        true,
+    );
+    assert!(!compiler.is_null(), "failed to create compiler");
+
+    let result = compile(compiler, std::ptr::null(), 96.0, std::ptr::null());
+    assert!(!result.error.is_null(), "invalid document compiled without an error");
+
+    let error = unsafe { CStr::from_ptr(result.error).to_string_lossy().into_owned() };
+    dbg!(&error);
+
+    free_compile_result(result);
+    free_compiler(compiler);
+
+    assert!(
+        error.contains("expected expression"),
+        "unexpected compiler error: {error}"
+    );
+
+    assert!(
+        error.contains("unclosed delimiter"),
+        "unexpected compiler error: {error}"
+    );
+}

--- a/src/typstsharp.tests/Tests.cs
+++ b/src/typstsharp.tests/Tests.cs
@@ -2,7 +2,6 @@
 using UglyToad.PdfPig;
 using UglyToad.PdfPig.Content;
 using UglyToad.PdfPig.DocumentLayoutAnalysis.TextExtractor;
-using UglyToad.PdfPig.DocumentLayoutAnalysis.WordExtractor;
 
 namespace typstsharp.tests;
 
@@ -29,7 +28,42 @@ public class Tests
         await Assert.That(plainText).Contains("Hello world’s");
     }
 
-    private string GetPlainText(byte[] pdf)
+    [Test]
+    public async Task BasicException()
+    {
+        const string source = "This is not a valid document: # what?";
+        var regexMatcher = StringMatcher.AsRegex(
+            @"^expected expression \(line 1, column \d+: `[^`]*`\)\r?");
+
+        await Assert.That(() =>
+            {
+                using var compiler = TypstCompiler.FromSource(source);
+                _ = compiler.Compile();
+            }).Throws<InvalidOperationException>()
+            .WithMessageMatching(regexMatcher);
+    }
+
+    [Test]
+    public async Task BasicExceptionWithTwoErrors()
+    {
+        const string content = """
+                               This is not a valid document: # what?
+
+                               As a test - this should be able to have a second error, as you can't use dollars here: $50
+                               """;
+        var regexMatcher = StringMatcher.AsRegex(
+            @"^expected expression \(line 1, column \d+: `[^`]*`\)\r?\n" +
+            @"unclosed delimiter \(line 3, column \d+: `[^`]*`\)$");
+        
+        await Assert.That(() =>
+            {
+                using var compiler = TypstCompiler.FromSource(content);
+                _ = compiler.Compile();
+            }).Throws<InvalidOperationException>()
+            .WithMessageMatching(regexMatcher);
+    }
+
+    private static string GetPlainText(byte[] pdf)
     {
         var sb = new StringBuilder();
         using (PdfDocument document = PdfDocument.Open(pdf))
@@ -37,7 +71,6 @@ public class Tests
             foreach (Page page in document.GetPages())
             {
                 string text = ContentOrderTextExtractor.GetText(page);
-                IEnumerable<Word> words = page.GetWords(NearestNeighbourWordExtractor.Instance);
                 sb.AppendLine(text);
             }
         }

--- a/src/typstsharp.tests/typstsharp.tests.csproj
+++ b/src/typstsharp.tests/typstsharp.tests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PdfPig" Version="0.1.13" />
-    <PackageReference Include="TUnit" Version="1.12.102" />
+    <PackageReference Include="PdfPig" Version="0.1.15" />
+    <PackageReference Include="TUnit" Version="1.64.6" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UsePackagedLibrary)' != 'true'">


### PR DESCRIPTION
Updated the Rust library to now include detailed error information including line and column # when possible.

Added two unit tests to validate proper error information for both a single error and multi-error case.

Updated .NET TUnit and PDF Pig libraries in the unit testing project (I had an issue with Rider and TUnit, so I updated them).

