### PR TITLE
Add macOS target

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,11 @@ The build will automatically:
 3. Add the libraries to the managed project's runtime assets so that `dotnet publish`/`dotnet pack` place the files under `runtimes/<rid>/native/` in the final artifact.
 4. For local development, the native binary for the host architecture is copied to the output directory of any project referencing `typstsharp`, ensuring it's available for debugging.
 
-You can override the target runtimes by setting the `RustTargets` property (e.g., `dotnet build -p:RustTargets=win-x64`).
+You can override the target runtimes by setting the `RustTargets` property (e.g., `dotnet build -p:RustTargets=win-x64`). On macOS, use `osx-arm64` for Apple Silicon or `osx-x64` for Intel:
+
+```bash
+dotnet build -p:RustTargets=osx-arm64
+```
 
 ## Verifying the CLI
 
@@ -118,7 +122,7 @@ You can override the target runtimes by setting the `RustTargets` property (e.g.
  dotnet run --project src/typstsharp.cli/typstsharp.cli.csproj
 ```
 
-Because the Rust binary is registered as a runtime asset, `typst_core.dll`/`libtypst_core.so` will appear beside the CLI executable automatically.
+Because the Rust binary is registered as a runtime asset, `typst_core.dll`, `libtypst_core.so`, or `libtypst_core.dylib` will appear beside the CLI executable automatically.
 
 ## Notes
 

--- a/src/typstsharp/typstsharp.csproj
+++ b/src/typstsharp/typstsharp.csproj
@@ -45,6 +45,14 @@
       <TargetTriple>x86_64-unknown-linux-musl</TargetTriple>
       <LibraryFileName>libtypst_core.so</LibraryFileName>
     </RustRuntime>
+    <RustRuntime Include="osx-x64">
+      <TargetTriple>x86_64-apple-darwin</TargetTriple>
+      <LibraryFileName>libtypst_core.dylib</LibraryFileName>
+    </RustRuntime>
+    <RustRuntime Include="osx-arm64">
+      <TargetTriple>aarch64-apple-darwin</TargetTriple>
+      <LibraryFileName>libtypst_core.dylib</LibraryFileName>
+    </RustRuntime>
 
   </ItemGroup>
 


### PR DESCRIPTION
I don't have an Apple Silicon to test with, but I do have an Intel based mac and can verify that the Rust build runs automatically and the proper dylib file is copied to the output directory. I executed `dotnet test` afterwards and all tests ran and passed.

I updated the README to include information about the macOS build. In my case the platform did autodetect and so I did not need to do anything, I just ran `dotnet build` for the solution and everything worked.

I don't know if there is any desire to add a macOS target, but it would be useful to me as I am working on a cross-platform project with both Windows and Mac being the primary audience. Feel free to mark the support as "experimental" or something like that.