### PR TITLE
feat: stream rendered output from native memory instead of copying it

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,30 @@ var pngResult = compiler.CompilePng(ppi: 300);
 byte[] page1Png = pngResult[0];
 ```
 
+### Zero-copy output
+
+`CompilePdf()` copies the rendered document onto the managed heap, which puts a multi-megabyte PDF on
+the large object heap. When the document is only on its way to a file, a response body or an upload,
+`CompileToDocument()` hands it over while it is still in the memory Typst allocated:
+
+```csharp
+using var compiler = TypstCompiler.FromSource("= Hello World!");
+using var document = compiler.CompileToDocument();
+
+ReadOnlySpan<byte> pdf = document.GetOutputSpan();   // no copy
+using Stream stream = document.OpenOutputStream();   // no copy, seekable, has a Length
+document.WriteOutputToFile("output.pdf");            // native memory straight to a file handle
+byte[] copy = document.GetOutputBytes();             // an explicit copy, when you need one
+```
+
+The document owns the native memory and must be disposed. Streams from `OpenOutputStream()` keep it
+alive and throw once it is disposed, so passing one to an SDK is safe. Spans from `GetOutputSpan()`
+do not, so they must not outlive the `using` block.
+
+A document is a list of output buffers rather than pages: PDF export produces one buffer for the
+whole document however many pages it has, while PNG and SVG produce one per page. `OutputCount` says
+how many there are, and every accessor takes an output index.
+
 ### Packages
 
 `packagePath` points the compiler at a directory of Typst packages, laid out as

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+ - Added `compiler.CompileToDocument(...)`, returning a disposable `TypstDocument` that exposes the rendered output while it is still in the memory the native library allocated. `GetOutputSpan`, `OpenOutputStream`, `CopyOutputTo`, `WriteOutputToFile` and `RentOutput` read it without putting a multi-megabyte PDF on the large object heap; `GetOutputBytes` copies when a `byte[]` is what you need.
  - Added easier PDF compilation APIs on `TypstCompiler`:
    - `compiler.CompilePdf(...)` returning a `PdfResult` (with implicit conversion to `byte[]`, `ReadOnlySpan<byte>`, and `ReadOnlyMemory<byte>`).
    - `compiler.CompilePdf(string outputFile)` / `compiler.CompilePdfAsync(string outputFile)` for direct file saving.
@@ -11,3 +12,7 @@
    - `outcome.AsPdf()` and `outcome.PrimaryBuffer` on `CompileOutcome`.
 - Added `includeSystemPackages` to `TypstCompiler`. Setting it to `false` resolves packages from `packagePath` only, so an import that is not vendored there fails instead of being downloaded from Typst Universe and compilation stays off the network.
 - Added support for compiling Typst documents with multiple PDF standards simultaneously (e.g. `v-1.7`, `a-2b`, etc.) by exposing a `pdfStandards` parameter in the `TypstCompiler.Compile` API, leveraging the underlying `typst-pdf` crate updates in Typst 0.15.
+
+### Changed
+- `compiler.CompilePdf(Stream)`, `compiler.CompilePdfAsync(Stream)`, `compiler.CompilePdf(string outputFile)` and `compiler.CompilePdfAsync(string outputFile)` now stream the document straight from native memory to the destination and return the compiler warnings, rather than returning a `PdfResult` that had to be materialised on the managed heap first. Use `compiler.CompilePdf()` when you want the bytes.
+- `compiler.Compile(outputFile, format)` and `compiler.CompileSvg(...)` no longer copy the rendered output onto the managed heap before writing or decoding it.

--- a/src/typstsharp.cli/Program.cs
+++ b/src/typstsharp.cli/Program.cs
@@ -32,8 +32,8 @@ var sysInputs = new Dictionary<string, string>
     { "data", System.Text.Json.JsonSerializer.Serialize(new DataObj { item = 17 }) }
 };
 clientFile.SetSysInputs(sysInputs);
-var pdfResult = clientFile.CompilePdf("output_file.pdf");
-Console.WriteLine($"Compiled output_file.pdf from input.typ ({pdfResult.Length} bytes)");
+clientFile.CompilePdf("output_file.pdf");
+Console.WriteLine($"Compiled output_file.pdf from input.typ ({new FileInfo("output_file.pdf").Length} bytes)");
 
 
 Console.WriteLine("\n--- Test 2: Compile from Source String ---");

--- a/src/typstsharp.tests/Tests.cs
+++ b/src/typstsharp.tests/Tests.cs
@@ -322,6 +322,409 @@ public class Tests
             .WithMessageContaining("package not found");
     }
 
+    [Test]
+    public async Task DocumentExposesOutputWithoutCopying()
+    {
+        using var compiler = TypstCompiler.FromSource("= Zero copy");
+        using var document = compiler.CompileToDocument();
+
+        await Assert.That(document.OutputCount).IsEqualTo(1);
+        await Assert.That(GetPlainText(document.GetOutputBytes())).Contains("Zero copy");
+    }
+
+    [Test]
+    public async Task OutputStreamHasSameContentAsOutputBytes()
+    {
+        using var compiler = TypstCompiler.FromSource("= Streamed");
+        using var document = compiler.CompileToDocument();
+        var expected = document.GetOutputBytes();
+
+        using var pageStream = document.OpenOutputStream();
+        using var copy = new MemoryStream();
+        pageStream.CopyTo(copy);
+
+        await Assert.That(pageStream.Length).IsEqualTo((long)expected.Length);
+        await Assert.That(copy.ToArray().SequenceEqual(expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task RentedOutputHasExactLengthAndSameContent()
+    {
+        using var compiler = TypstCompiler.FromSource("= Pooled");
+        using var document = compiler.CompileToDocument();
+        var expected = document.GetOutputBytes();
+
+        using var rented = document.RentOutput();
+
+        await Assert.That(rented.Memory.Length).IsEqualTo(expected.Length);
+        await Assert.That(rented.Memory.ToArray().SequenceEqual(expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task WriteOutputToFileMatchesOutputBytes()
+    {
+        using var compiler = TypstCompiler.FromSource("= Written directly to disk");
+        using var document = compiler.CompileToDocument();
+        var expected = document.GetOutputBytes();
+        var path = GetTempFilePath(".pdf");
+
+        try
+        {
+            document.WriteOutputToFile(path);
+            var written = await File.ReadAllBytesAsync(path);
+
+            await Assert.That(written.Length).IsEqualTo(expected.Length);
+            await Assert.That(written.SequenceEqual(expected)).IsTrue();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task WriteOutputToFileAsyncMatchesOutputBytes()
+    {
+        using var compiler = TypstCompiler.FromSource("= Written asynchronously");
+        using var document = compiler.CompileToDocument();
+        var expected = document.GetOutputBytes();
+        var path = GetTempFilePath(".pdf");
+
+        try
+        {
+            await document.WriteOutputToFileAsync(path);
+            var written = await File.ReadAllBytesAsync(path);
+
+            await Assert.That(written.Length).IsEqualTo(expected.Length);
+            await Assert.That(written.SequenceEqual(expected)).IsTrue();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task CompilingToAFileProducesReadablePdf()
+    {
+        using var compiler = TypstCompiler.FromSource("= Compiled straight to a file");
+        var path = GetTempFilePath(".pdf");
+
+        try
+        {
+            compiler.Compile(path, "pdf");
+
+            await Assert.That(GetPlainText(await File.ReadAllBytesAsync(path))).Contains("straight to a file");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task MultiPageOutputIsWrittenToNumberedFiles()
+    {
+        using var compiler = TypstCompiler.FromSource(TwoPageSource);
+        var directory = CreateTempDirectory();
+
+        try
+        {
+            compiler.Compile(Path.Combine(directory, "page.png"), "png");
+
+            await Assert.That(File.Exists(Path.Combine(directory, "page-1.png"))).IsTrue();
+            await Assert.That(File.Exists(Path.Combine(directory, "page-2.png"))).IsTrue();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task DisposedDocumentRejectsOutputAccess()
+    {
+        using var compiler = TypstCompiler.FromSource("= Disposed");
+        var document = compiler.CompileToDocument();
+        document.Dispose();
+
+        await Assert.That(() => document.GetOutputBytes()).Throws<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task DisposingADocumentTwiceIsSafe()
+    {
+        using var compiler = TypstCompiler.FromSource("= Disposed twice");
+        var document = compiler.CompileToDocument();
+
+        document.Dispose();
+        document.Dispose();
+
+        await Assert.That(document.OutputCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task UnknownOutputIndexIsRejected()
+    {
+        using var compiler = TypstCompiler.FromSource("= Single page");
+        using var document = compiler.CompileToDocument();
+
+        await Assert.That(() => document.GetOutputBytes(1)).Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => document.GetOutputBytes(-1)).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WarningsRemainReadableAfterDisposal()
+    {
+        using var compiler = TypstCompiler.FromSource(WarningSource);
+        var document = compiler.CompileToDocument();
+        document.Dispose();
+
+        await Assert.That(document.Warnings.Count).IsGreaterThan(0);
+    }
+
+    // An S3 upload hands the stream to the AWS SDK, which reads its length and rewinds to retry.
+    [Test]
+    public async Task OutputStreamIsSeekableAndCanBeReRead()
+    {
+        using var compiler = TypstCompiler.FromSource("= Uploaded");
+        using var document = compiler.CompileToDocument();
+        var expected = document.GetOutputBytes();
+
+        using var stream = document.OpenOutputStream();
+        await Assert.That(stream.CanSeek).IsTrue();
+        await Assert.That(stream.Length).IsEqualTo((long)expected.Length);
+
+        var first = new byte[expected.Length];
+        stream.ReadExactly(first);
+
+        stream.Seek(0, SeekOrigin.Begin);
+        var second = new byte[expected.Length];
+        stream.ReadExactly(second);
+
+        await Assert.That(first.SequenceEqual(expected)).IsTrue();
+        await Assert.That(second.SequenceEqual(expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task OutputStreamRejectsReadsAfterTheDocumentIsDisposed()
+    {
+        using var compiler = TypstCompiler.FromSource("= Disposed underneath");
+        var document = compiler.CompileToDocument();
+        var stream = document.OpenOutputStream();
+
+        document.Dispose();
+
+        await Assert.That(() => stream.ReadByte()).Throws<ObjectDisposedException>();
+        await Assert.That(() => stream.Read(new byte[16], 0, 16)).Throws<ObjectDisposedException>();
+        await Assert.That(() => stream.Read(new byte[16].AsSpan())).Throws<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task OutputLengthMatchesOutputBytes()
+    {
+        using var compiler = TypstCompiler.FromSource("= Measured");
+        using var document = compiler.CompileToDocument();
+
+        await Assert.That(document.GetOutputLength()).IsEqualTo((long)document.GetOutputBytes().Length);
+    }
+
+    [Test]
+    public async Task CopyOutputToWritesTheWholeBuffer()
+    {
+        using var compiler = TypstCompiler.FromSource("= Copied");
+        using var document = compiler.CompileToDocument();
+        var expected = document.GetOutputBytes();
+
+        using var sync = new MemoryStream();
+        document.CopyOutputTo(sync);
+
+        using var async = new MemoryStream();
+        await document.CopyOutputToAsync(async);
+
+        await Assert.That(sync.ToArray().SequenceEqual(expected)).IsTrue();
+        await Assert.That(async.ToArray().SequenceEqual(expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task RentedOutputIsUnusableAfterDisposalAndSafeToDisposeTwice()
+    {
+        using var compiler = TypstCompiler.FromSource("= Returned to the pool");
+        using var document = compiler.CompileToDocument();
+
+        var rented = document.RentOutput();
+        rented.Dispose();
+        rented.Dispose();
+
+        await Assert.That(() => rented.Memory).Throws<ObjectDisposedException>();
+    }
+
+    // The written file must not keep a tail from whatever was there before.
+    [Test]
+    public async Task WriteOutputToFileTruncatesALargerExistingFile()
+    {
+        using var compiler = TypstCompiler.FromSource("= Overwritten");
+        using var document = compiler.CompileToDocument();
+        var expected = document.GetOutputBytes();
+        var path = GetTempFilePath(".pdf");
+
+        try
+        {
+            await File.WriteAllBytesAsync(path, new byte[expected.Length * 2]);
+            document.WriteOutputToFile(path);
+            var written = await File.ReadAllBytesAsync(path);
+
+            await Assert.That(written.Length).IsEqualTo(expected.Length);
+            await Assert.That(written.SequenceEqual(expected)).IsTrue();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task MultiPageFilesHaveDistinctContent()
+    {
+        using var compiler = TypstCompiler.FromSource(TwoPageSource);
+        var directory = CreateTempDirectory();
+
+        try
+        {
+            compiler.Compile(Path.Combine(directory, "page.png"), "png");
+            var first = await File.ReadAllBytesAsync(Path.Combine(directory, "page-1.png"));
+            var second = await File.ReadAllBytesAsync(Path.Combine(directory, "page-2.png"));
+
+            await Assert.That(first.Length).IsGreaterThan(0);
+            await Assert.That(second.Length).IsGreaterThan(0);
+            await Assert.That(first.SequenceEqual(second)).IsFalse();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    // PNG and SVG render one buffer per page, so the copying path has to surface all of them.
+    [Test]
+    public async Task CompileStillReturnsOneBufferPerPageForPng()
+    {
+        using var compiler = TypstCompiler.FromSource(TwoPageSource);
+
+        var outcome = compiler.Compile("png");
+
+        // Buffers is the member under test here, obsolete or not.
+#pragma warning disable CS0618
+        await Assert.That(outcome.Buffers.Count).IsEqualTo(2);
+        await Assert.That(outcome.Buffers[0].Length).IsGreaterThan(0);
+        await Assert.That(outcome.Buffers[0].SequenceEqual(outcome.Buffers[1])).IsFalse();
+#pragma warning restore CS0618
+    }
+
+    [Test]
+    public async Task PdfOutputIsASingleBufferRegardlessOfPageCount()
+    {
+        using var compiler = TypstCompiler.FromSource(TwoPageSource);
+        using var document = compiler.CompileToDocument();
+
+        await Assert.That(document.OutputCount).IsEqualTo(1);
+    }
+
+    // An unresolvable font family warns without failing the compilation, so the streaming overloads
+    // have something to report through the only channel they still have.
+    private const string WarningSource = """
+                                         #set text(font: "No Such Font Family")
+                                         Warned
+                                         """;
+
+    [Test]
+    public async Task StreamingToAStreamReturnsCompilerWarnings()
+    {
+        using var compiler = TypstCompiler.FromSource(WarningSource);
+        using var target = new MemoryStream();
+
+        var warnings = compiler.CompilePdf(target);
+
+        await Assert.That(warnings.Count).IsGreaterThan(0);
+        await Assert.That(GetPlainText(target.ToArray())).Contains("Warned");
+    }
+
+    [Test]
+    public async Task StreamingToAStreamAsynchronouslyReturnsCompilerWarnings()
+    {
+        using var compiler = TypstCompiler.FromSource(WarningSource);
+        using var target = new MemoryStream();
+
+        var warnings = await compiler.CompilePdfAsync(target);
+
+        await Assert.That(warnings.Count).IsGreaterThan(0);
+        await Assert.That(GetPlainText(target.ToArray())).Contains("Warned");
+    }
+
+    [Test]
+    public async Task StreamingToAFileReturnsCompilerWarnings()
+    {
+        using var compiler = TypstCompiler.FromSource(WarningSource);
+        var path = GetTempFilePath(".pdf");
+
+        try
+        {
+            var warnings = compiler.CompilePdf(path);
+
+            await Assert.That(warnings.Count).IsGreaterThan(0);
+            await Assert.That(GetPlainText(await File.ReadAllBytesAsync(path))).Contains("Warned");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task StreamingToAFileAsynchronouslyReturnsCompilerWarnings()
+    {
+        using var compiler = TypstCompiler.FromSource(WarningSource);
+        var path = GetTempFilePath(".pdf");
+
+        try
+        {
+            var warnings = await compiler.CompilePdfAsync(path);
+
+            await Assert.That(warnings.Count).IsGreaterThan(0);
+            await Assert.That(GetPlainText(await File.ReadAllBytesAsync(path))).Contains("Warned");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task WarningsFromADocumentCannotBeMutatedByCallers()
+    {
+        using var compiler = TypstCompiler.FromSource(WarningSource);
+        using var document = compiler.CompileToDocument();
+
+        await Assert.That(document.Warnings.Count).IsGreaterThan(0);
+        await Assert.That(document.Warnings is string[]).IsFalse();
+    }
+
+    private const string TwoPageSource = """
+                                         First page
+                                         #pagebreak()
+                                         Second page
+                                         """;
+
+    private static string GetTempFilePath(string extension) =>
+        Path.Combine(Path.GetTempPath(), $"typstsharp-test-{Guid.NewGuid():N}{extension}");
+
+    private static string CreateTempDirectory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"typstsharp-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
     private static string GetPlainText(byte[] pdf)
     {
         var sb = new StringBuilder();

--- a/src/typstsharp/NativeBuffers.cs
+++ b/src/typstsharp/NativeBuffers.cs
@@ -1,0 +1,98 @@
+using System.Buffers;
+
+namespace typstsharp;
+
+/// <summary>
+/// Exposes a block of Typst-owned native memory as <see cref="Memory{T}"/> so that it can be handed
+/// to asynchronous APIs, which need <see cref="ReadOnlyMemory{T}"/> rather than a span, without
+/// copying it onto the managed heap first.
+/// </summary>
+/// <remarks>
+/// The memory is owned by the native side; this manager neither allocates nor frees it. It holds a
+/// reference to the owning <see cref="TypstDocument"/> so that the document cannot be finalized, and
+/// its memory freed, while a write from this buffer is still in flight.
+/// </remarks>
+internal sealed unsafe class NativeBufferMemoryManager : MemoryManager<byte>
+{
+    private readonly TypstDocument _owner;
+    private readonly byte* _pointer;
+    private readonly int _length;
+
+    public NativeBufferMemoryManager(TypstDocument owner, byte* pointer, int length)
+    {
+        _owner = owner;
+        _pointer = pointer;
+        _length = length;
+    }
+
+    public override Span<byte> GetSpan()
+    {
+        ObjectDisposedException.ThrowIf(_owner.IsDisposed, _owner);
+        return new Span<byte>(_pointer, _length);
+    }
+
+    /// <summary>
+    /// Native memory is never relocated by the GC, so pinning is a no-op and only has to hand back
+    /// the address of the requested element. One past the end is allowed, matching the semantics of
+    /// <see cref="Memory{T}"/> over an array.
+    /// </summary>
+    public override MemoryHandle Pin(int elementIndex = 0)
+    {
+        ObjectDisposedException.ThrowIf(_owner.IsDisposed, _owner);
+
+        if ((uint)elementIndex > (uint)_length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(elementIndex));
+        }
+
+        return new MemoryHandle(_pointer + elementIndex);
+    }
+
+    public override void Unpin()
+    {
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        GC.KeepAlive(_owner);
+    }
+}
+
+/// <summary>
+/// An <see cref="IMemoryOwner{T}"/> backed by <see cref="ArrayPool{T}.Shared"/>, exposing exactly the
+/// requested number of bytes rather than the (potentially larger) rented array.
+/// </summary>
+/// <remarks>
+/// The buffer is cleared before it goes back to the pool. <see cref="ArrayPool{T}.Shared"/> is
+/// process-wide and shared with everything else in the host, and what we put in it is a rendered
+/// document, so leaving the content behind for an unrelated component to rent would be a disclosure
+/// waiting to happen. Only the used prefix is cleared, so the cost is proportional to the document
+/// rather than to the (rounded up) rented array.
+/// </remarks>
+internal sealed class PooledBuffer : IMemoryOwner<byte>
+{
+    private byte[]? _array;
+    private readonly int _length;
+
+    public PooledBuffer(int length)
+    {
+        _array = ArrayPool<byte>.Shared.Rent(length);
+        _length = length;
+    }
+
+    public Memory<byte> Memory => new(Array, 0, _length);
+
+    public Span<byte> Span => new(Array, 0, _length);
+
+    private byte[] Array => _array ?? throw new ObjectDisposedException(nameof(PooledBuffer));
+
+    public void Dispose()
+    {
+        var array = Interlocked.Exchange(ref _array, null);
+        if (array is not null)
+        {
+            array.AsSpan(0, _length).Clear();
+            ArrayPool<byte>.Shared.Return(array);
+        }
+    }
+}

--- a/src/typstsharp/TypstCompiler.cs
+++ b/src/typstsharp/TypstCompiler.cs
@@ -289,11 +289,20 @@ public class TypstCompiler : IDisposable
     }
 
     /// <summary>
-    /// Compiles the Typst document.
+    /// Compiles the Typst document and hands back the rendered output while it is still in the memory
+    /// the native library allocated, without copying it onto the managed heap. The caller decides
+    /// whether the bytes are ever copied.
     /// </summary>
-    /// <returns>A <see cref="CompileOutcome"/> containing the compiled document buffers and any warnings.</returns>
+    /// <param name="format">The output format: "pdf", "png" or "svg".</param>
+    /// <param name="ppi">The pixels per inch used for raster output.</param>
+    /// <param name="pdfStandards">Optional PDF standards (e.g. "a-2b", "v-1.7").</param>
+    /// <returns>A <see cref="TypstDocument"/> that must be disposed to release the native memory.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the compilation fails, with the error message from Typst.</exception>
-    public unsafe CompileOutcome Compile(string format = "pdf", float ppi = 144.0f, IEnumerable<string>? pdfStandards = null)
+    /// <remarks>
+    /// The returned document is independent of this compiler and stays valid after the compiler has
+    /// been disposed.
+    /// </remarks>
+    public unsafe TypstDocument CompileToDocument(string format = "pdf", float ppi = 144.0f, IEnumerable<string>? pdfStandards = null)
     {
         EnsureNotDisposed();
 
@@ -304,6 +313,12 @@ public class TypstCompiler : IDisposable
         try
         {
             var native = CsBindgen.NativeMethods.compile(_compiler, (byte*)formatPtr, ppi, (byte*)standardsPtr);
+
+            // The P/Invoke is a preemptive-mode transition, so a collection can run while Typst is
+            // compiling. `this` is dead from the field load above onwards, so without this the
+            // finalizer could free the native world underneath the call that is still using it.
+            GC.KeepAlive(this);
+
             try
             {
                 if (native.error_ptr != null)
@@ -312,39 +327,17 @@ public class TypstCompiler : IDisposable
                     throw new InvalidOperationException(error);
                 }
 
-                var managedBuffers = new List<byte[]>((int)native.buffers_len);
-                if (native.buffers != null)
-                {
-                    for (nuint i = 0; i < native.buffers_len; i++)
-                    {
-                        var buffer = native.buffers[i];
-                        var managed = new byte[checked((int)buffer.len)];
-                        if (buffer.len > 0 && buffer.ptr != null)
-                        {
-                            Marshal.Copy((IntPtr)buffer.ptr, managed, 0, managed.Length);
-                        }
-                        managedBuffers.Add(managed);
-                    }
-                }
-
-                var managedWarnings = new List<string>((int)native.warnings_len);
-                if (native.warnings != null)
-                {
-                    for (nuint i = 0; i < native.warnings_len; i++)
-                    {
-                        var warning = native.warnings[i];
-                        string warningText = warning.message_ptr != null 
-                            ? System.Text.Encoding.UTF8.GetString(new ReadOnlySpan<byte>(warning.message_ptr, checked((int)warning.message_len))) 
-                            : string.Empty;
-                        managedWarnings.Add(warningText);
-                    }
-                }
-
-                return new CompileOutcome(managedBuffers, managedWarnings);
+                // From here on the document owns the native result and frees it when disposed.
+                return new TypstDocument(native);
+            }
+            catch
+            {
+                CsBindgen.NativeMethods.free_compile_result(native);
+                throw;
             }
             finally
             {
-                CsBindgen.NativeMethods.free_compile_result(native);
+                // Trims the incremental compilation cache; independent of who owns the buffers.
                 CsBindgen.NativeMethods.reset_world();
             }
         }
@@ -353,6 +346,24 @@ public class TypstCompiler : IDisposable
             if (formatPtr != IntPtr.Zero) Marshal.FreeCoTaskMem(formatPtr);
             if (standardsPtr != IntPtr.Zero) Marshal.FreeCoTaskMem(standardsPtr);
         }
+    }
+
+    /// <summary>
+    /// Compiles the Typst document and copies the rendered output onto the managed heap.
+    /// </summary>
+    /// <returns>A <see cref="CompileOutcome"/> containing the compiled document buffers and any warnings.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the compilation fails, with the error message from Typst.</exception>
+    public CompileOutcome Compile(string format = "pdf", float ppi = 144.0f, IEnumerable<string>? pdfStandards = null)
+    {
+        using var document = CompileToDocument(format, ppi, pdfStandards);
+
+        var managedBuffers = new List<byte[]>(document.OutputCount);
+        for (int i = 0; i < document.OutputCount; i++)
+        {
+            managedBuffers.Add(document.GetOutputBytes(i));
+        }
+
+        return new CompileOutcome(managedBuffers, document.Warnings);
     }
 
     /// <summary>
@@ -367,59 +378,69 @@ public class TypstCompiler : IDisposable
     }
 
     /// <summary>
-    /// Compiles the Typst document to a PDF and writes the output directly to a file.
+    /// Compiles the Typst document to a PDF and streams it straight to a file, without
+    /// buffering it on the managed heap.
     /// </summary>
     /// <param name="outputFile">The path of the destination PDF file.</param>
     /// <param name="pdfStandards">Optional PDF standards (e.g. "a-2b", "v-1.7").</param>
-    /// <returns>A <see cref="PdfResult"/> containing the PDF bytes and any warnings.</returns>
-    public PdfResult CompilePdf(string outputFile, IEnumerable<string>? pdfStandards = null)
+    /// <returns>The warnings reported by the Typst compiler.</returns>
+    public IReadOnlyList<string> CompilePdf(string outputFile, IEnumerable<string>? pdfStandards = null)
     {
-        var result = CompilePdf(pdfStandards);
-        result.Save(outputFile);
-        return result;
+        ArgumentException.ThrowIfNullOrEmpty(outputFile);
+
+        using var document = CompileToDocument("pdf", pdfStandards: pdfStandards);
+        document.WriteOutputToFile(outputFile);
+        return document.Warnings;
     }
 
     /// <summary>
-    /// Compiles the Typst document to a PDF and writes the output directly to a file asynchronously.
+    /// Asynchronously compiles the Typst document to a PDF and streams it straight to a file,
+    /// without buffering it on the managed heap.
     /// </summary>
     /// <param name="outputFile">The path of the destination PDF file.</param>
     /// <param name="pdfStandards">Optional PDF standards (e.g. "a-2b", "v-1.7").</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A <see cref="PdfResult"/> containing the PDF bytes and any warnings.</returns>
-    public async Task<PdfResult> CompilePdfAsync(string outputFile, IEnumerable<string>? pdfStandards = null, CancellationToken cancellationToken = default)
+    /// <returns>The warnings reported by the Typst compiler.</returns>
+    public async Task<IReadOnlyList<string>> CompilePdfAsync(string outputFile, IEnumerable<string>? pdfStandards = null, CancellationToken cancellationToken = default)
     {
-        var result = CompilePdf(pdfStandards);
-        await result.SaveAsync(outputFile, cancellationToken).ConfigureAwait(false);
-        return result;
+        ArgumentException.ThrowIfNullOrEmpty(outputFile);
+
+        using var document = CompileToDocument("pdf", pdfStandards: pdfStandards);
+        await document.WriteOutputToFileAsync(outputFile, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return document.Warnings;
     }
 
     /// <summary>
-    /// Compiles the Typst document to a PDF and writes the bytes to a stream.
+    /// Compiles the Typst document to a PDF and writes it to a stream, without buffering it on
+    /// the managed heap.
     /// </summary>
     /// <param name="destination">The destination stream to write the PDF bytes to.</param>
     /// <param name="pdfStandards">Optional PDF standards (e.g. "a-2b", "v-1.7").</param>
-    /// <returns>A <see cref="PdfResult"/> containing the PDF bytes and any warnings.</returns>
-    public PdfResult CompilePdf(Stream destination, IEnumerable<string>? pdfStandards = null)
+    /// <returns>The warnings reported by the Typst compiler.</returns>
+    public IReadOnlyList<string> CompilePdf(Stream destination, IEnumerable<string>? pdfStandards = null)
     {
         ArgumentNullException.ThrowIfNull(destination);
-        var result = CompilePdf(pdfStandards);
-        destination.Write(result.Bytes, 0, result.Bytes.Length);
-        return result;
+
+        using var document = CompileToDocument("pdf", pdfStandards: pdfStandards);
+        document.CopyOutputTo(destination);
+        return document.Warnings;
     }
 
     /// <summary>
-    /// Compiles the Typst document to a PDF and writes the bytes to a stream asynchronously.
+    /// Asynchronously compiles the Typst document to a PDF and writes it to a stream, without
+    /// buffering it on the managed heap.
     /// </summary>
     /// <param name="destination">The destination stream to write the PDF bytes to.</param>
     /// <param name="pdfStandards">Optional PDF standards (e.g. "a-2b", "v-1.7").</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A <see cref="PdfResult"/> containing the PDF bytes and any warnings.</returns>
-    public async Task<PdfResult> CompilePdfAsync(Stream destination, IEnumerable<string>? pdfStandards = null, CancellationToken cancellationToken = default)
+    /// <returns>The warnings reported by the Typst compiler.</returns>
+    public async Task<IReadOnlyList<string>> CompilePdfAsync(Stream destination, IEnumerable<string>? pdfStandards = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(destination);
-        var result = CompilePdf(pdfStandards);
-        await destination.WriteAsync(result.Bytes, cancellationToken).ConfigureAwait(false);
-        return result;
+
+        using var document = CompileToDocument("pdf", pdfStandards: pdfStandards);
+        await document.CopyOutputToAsync(destination, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return document.Warnings;
     }
 
     /// <summary>
@@ -429,11 +450,16 @@ public class TypstCompiler : IDisposable
     /// <returns>A <see cref="SvgResult"/> containing SVG string per page and any warnings.</returns>
     public SvgResult CompileSvg(float ppi = 144.0f)
     {
-        var outcome = Compile(format: "svg", ppi: ppi);
-        var pages = outcome.Buffers
-            .Select(b => System.Text.Encoding.UTF8.GetString(b))
-            .ToList();
-        return new SvgResult(pages, outcome.Warnings);
+        using var document = CompileToDocument(format: "svg", ppi: ppi);
+
+        var pages = new List<string>(document.OutputCount);
+        for (int i = 0; i < document.OutputCount; i++)
+        {
+            // Decoding straight from native memory skips the intermediate byte[] per page.
+            pages.Add(System.Text.Encoding.UTF8.GetString(document.GetOutputSpan(i)));
+        }
+
+        return new SvgResult(pages, document.Warnings);
     }
 
     /// <summary>
@@ -443,8 +469,15 @@ public class TypstCompiler : IDisposable
     /// <returns>A <see cref="PngResult"/> containing PNG bytes per page and any warnings.</returns>
     public PngResult CompilePng(float ppi = 144.0f)
     {
-        var outcome = Compile(format: "png", ppi: ppi);
-        return new PngResult(outcome.Buffers, outcome.Warnings);
+        using var document = CompileToDocument(format: "png", ppi: ppi);
+
+        var pages = new List<byte[]>(document.OutputCount);
+        for (int i = 0; i < document.OutputCount; i++)
+        {
+            pages.Add(document.GetOutputBytes(i));
+        }
+
+        return new PngResult(pages, document.Warnings);
     }
 
     public record TypstWarning(string Message);
@@ -473,22 +506,24 @@ public class TypstCompiler : IDisposable
     /// <param name="ppi">The pixels per inch for the output. This parameter is currently not used by the underlying engine but is kept for future compatibility.</param>
     public void Compile(string outputFile, string format, float ppi = 144.0f, IEnumerable<string>? pdfStandards = null)
     {
-        var (pages, _) = CompileToPages(format, ppi, pdfStandards);
-        if (pages.Count == 1)
-        {
-            File.WriteAllBytes(outputFile, pages[0]);
-        }
-        else
-        {
-            var extension = Path.GetExtension(outputFile);
-            var fileName = Path.GetFileNameWithoutExtension(outputFile);
-            var directory = Path.GetDirectoryName(outputFile) ?? "";
+        ArgumentException.ThrowIfNullOrEmpty(outputFile);
 
-            for (int i = 0; i < pages.Count; i++)
-            {
-                var pagePath = Path.Combine(directory, $"{fileName}-{i + 1}{extension}");
-                File.WriteAllBytes(pagePath, pages[i]);
-            }
+        using var document = CompileToDocument(format, ppi, pdfStandards);
+        if (document.OutputCount == 1)
+        {
+            document.WriteOutputToFile(outputFile);
+            return;
+        }
+
+        // A format that renders one buffer per page gets a page number appended, so "out.png"
+        // becomes "out-1.png", "out-2.png" and so on.
+        var directory = Path.GetDirectoryName(outputFile) ?? "";
+        var fileName = Path.GetFileNameWithoutExtension(outputFile);
+        var extension = Path.GetExtension(outputFile);
+
+        for (int i = 0; i < document.OutputCount; i++)
+        {
+            document.WriteOutputToFile(Path.Combine(directory, $"{fileName}-{i + 1}{extension}"), i);
         }
     }
 

--- a/src/typstsharp/TypstDocument.cs
+++ b/src/typstsharp/TypstDocument.cs
@@ -1,0 +1,357 @@
+using System.Buffers;
+using Microsoft.Win32.SafeHandles;
+
+namespace typstsharp;
+
+/// <summary>
+/// The result of a single Typst compilation, holding the rendered output in the memory allocated by
+/// the native Typst library.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nothing is copied onto the managed heap while the document is alive: the output can be read as a
+/// <see cref="ReadOnlySpan{T}"/>, streamed, or written straight to disk. This keeps a multi-megabyte
+/// PDF off the large object heap, which matters when documents are rendered in a loop or on a server.
+/// </para>
+/// <para>
+/// A document is a list of output buffers, not of pages. PDF export produces exactly one buffer
+/// containing the whole document however many pages it has; PNG and SVG export produce one buffer
+/// per page. See <see cref="OutputCount"/>.
+/// </para>
+/// <para>
+/// The native memory is released by <see cref="Dispose"/>. A <see cref="ReadOnlySpan{T}"/> from
+/// <see cref="GetOutputSpan"/> points into that memory and carries no reference back to the
+/// document, so it is only valid inside the scope that holds the document. Streams from
+/// <see cref="OpenOutputStream"/> do keep the document alive and throw once it is disposed.
+/// <see cref="GetOutputBytes"/> and <see cref="RentOutput"/> return memory that survives disposal.
+/// </para>
+/// <para>
+/// Reading a document from several threads at once is safe; disposing it while another thread reads
+/// is not. Concurrent calls to <see cref="Dispose"/> are safe.
+/// </para>
+/// </remarks>
+public sealed class TypstDocument : IDisposable
+{
+    private unsafe CsBindgen.CompileResult _native;
+    private readonly int _outputCount;
+    private readonly IReadOnlyList<string> _warnings;
+    private readonly long _nativeByteCount;
+    private int _disposed;
+
+    internal unsafe TypstDocument(CsBindgen.CompileResult native)
+    {
+        int outputCount = checked((int)native.buffers_len);
+        if (outputCount > 0 && native.buffers == null)
+        {
+            throw new InvalidOperationException("The Typst compiler reported output buffers but returned none.");
+        }
+
+        int warningCount = checked((int)native.warnings_len);
+        if (warningCount > 0 && native.warnings == null)
+        {
+            throw new InvalidOperationException("The Typst compiler reported warnings but returned none.");
+        }
+
+        // Warnings are small and are copied eagerly so that they stay usable after disposal.
+        var warnings = new string[warningCount];
+        for (int i = 0; i < warnings.Length; i++)
+        {
+            var warning = native.warnings[i];
+            warnings[i] = warning.message_ptr != null
+                ? System.Text.Encoding.UTF8.GetString(new ReadOnlySpan<byte>(warning.message_ptr, checked((int)warning.message_len)))
+                : string.Empty;
+        }
+
+        long nativeByteCount = 0;
+        for (int i = 0; i < outputCount; i++)
+        {
+            nativeByteCount += (long)native.buffers[i].len;
+        }
+
+        _outputCount = outputCount;
+        _warnings = Array.AsReadOnly(warnings);
+        _nativeByteCount = nativeByteCount;
+
+        // Taking ownership must be the last thing that happens. An object with a finalizer is queued
+        // for finalization when it is allocated, so a constructor that threw after this point would
+        // leave behind a finalizer that frees a result the caller has already freed.
+        _native = native;
+
+        // The rendered bytes live outside the managed heap and are invisible to the GC. Without this
+        // a leaked document would exert no collection pressure at all.
+        if (nativeByteCount > 0)
+        {
+            GC.AddMemoryPressure(nativeByteCount);
+        }
+    }
+
+    /// <summary>
+    /// The number of output buffers. This is 1 for PDF export regardless of how many pages the
+    /// document has, and one per page for PNG and SVG export.
+    /// </summary>
+    public int OutputCount => _outputCount;
+
+    /// <summary>Warnings reported by the Typst compiler.</summary>
+    public IReadOnlyList<string> Warnings => _warnings;
+
+    internal bool IsDisposed => Volatile.Read(ref _disposed) != 0;
+
+    /// <summary>
+    /// The length in bytes of one output buffer, without touching its content. Useful for setting a
+    /// response Content-Length before streaming the document.
+    /// </summary>
+    /// <param name="output">The zero-based buffer index; defaults to the only buffer of a PDF.</param>
+    public unsafe long GetOutputLength(int output = 0)
+    {
+        long length = (long)GetBuffer(output).len;
+        KeepAlive();
+        return length;
+    }
+
+    /// <summary>
+    /// Gets an output buffer as a view over the native memory, without copying.
+    /// </summary>
+    /// <param name="output">The zero-based buffer index; defaults to the only buffer of a PDF.</param>
+    /// <returns>
+    /// A span that carries no reference back to the document. It is only valid inside the scope that
+    /// holds the document, which a <c>using</c> declaration guarantees. To hand the bytes to code
+    /// that outlives this scope, use <see cref="OpenOutputStream"/>, <see cref="RentOutput"/> or
+    /// <see cref="GetOutputBytes"/> instead.
+    /// </returns>
+    public unsafe ReadOnlySpan<byte> GetOutputSpan(int output = 0)
+    {
+        var buffer = GetBuffer(output);
+        return new ReadOnlySpan<byte>(buffer.ptr, ToLength(buffer.len));
+    }
+
+    /// <summary>
+    /// Opens a read-only, seekable stream over an output buffer. The stream reads directly from the
+    /// native memory, keeps the document alive for as long as it is referenced, and throws
+    /// <see cref="ObjectDisposedException"/> once the document has been disposed.
+    /// </summary>
+    /// <param name="output">The zero-based buffer index; defaults to the only buffer of a PDF.</param>
+    public unsafe Stream OpenOutputStream(int output = 0)
+    {
+        var buffer = GetBuffer(output);
+        return new OutputStream(this, buffer.ptr, (long)buffer.len);
+    }
+
+    /// <summary>
+    /// Writes an output buffer to <paramref name="destination"/> without an intermediate managed buffer.
+    /// </summary>
+    /// <param name="destination">The stream to write to.</param>
+    /// <param name="output">The zero-based buffer index; defaults to the only buffer of a PDF.</param>
+    public unsafe void CopyOutputTo(Stream destination, int output = 0)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+        destination.Write(GetOutputSpan(output));
+        KeepAlive();
+    }
+
+    /// <summary>
+    /// Asynchronously writes an output buffer to <paramref name="destination"/> without an
+    /// intermediate managed buffer.
+    /// </summary>
+    /// <param name="destination">The stream to write to.</param>
+    /// <param name="output">The zero-based buffer index; defaults to the only buffer of a PDF.</param>
+    /// <param name="cancellationToken">Token to cancel the write.</param>
+    /// <remarks>
+    /// The destination must not retain the memory it is handed past the completion of the write; it
+    /// points into memory this document owns.
+    /// </remarks>
+    public async ValueTask CopyOutputToAsync(Stream destination, int output = 0, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+        using var manager = CreateBufferManager(output);
+        await destination.WriteAsync(manager.Memory, cancellationToken).ConfigureAwait(false);
+        KeepAlive();
+    }
+
+    /// <summary>
+    /// Writes an output buffer straight to a file, overwriting it if it exists. The bytes go from
+    /// native memory to the file handle, so nothing proportional to the document size is allocated
+    /// on the managed heap.
+    /// </summary>
+    /// <param name="path">The file to create or overwrite.</param>
+    /// <param name="output">The zero-based buffer index; defaults to the only buffer of a PDF.</param>
+    public unsafe void WriteOutputToFile(string path, int output = 0)
+    {
+        var content = GetOutputSpan(output);
+        using (var handle = OpenFile(path, content.Length, FileOptions.None))
+        {
+            RandomAccess.Write(handle, content, fileOffset: 0);
+        }
+
+        KeepAlive();
+    }
+
+    /// <summary>
+    /// Asynchronously writes an output buffer straight to a file, overwriting it if it exists,
+    /// without an intermediate managed buffer.
+    /// </summary>
+    /// <param name="path">The file to create or overwrite.</param>
+    /// <param name="output">The zero-based buffer index; defaults to the only buffer of a PDF.</param>
+    /// <param name="cancellationToken">Token to cancel the write. A cancelled write leaves a partial file behind.</param>
+    public async Task WriteOutputToFileAsync(string path, int output = 0, CancellationToken cancellationToken = default)
+    {
+        using var manager = CreateBufferManager(output);
+        using var handle = OpenFile(path, manager.Memory.Length, FileOptions.Asynchronous);
+        await RandomAccess.WriteAsync(handle, manager.Memory, fileOffset: 0, cancellationToken).ConfigureAwait(false);
+        KeepAlive();
+    }
+
+    /// <summary>
+    /// Copies an output buffer into a buffer rented from <see cref="ArrayPool{T}"/>. Use this when
+    /// the bytes have to outlive the document but the allocation should be recycled rather than
+    /// collected.
+    /// </summary>
+    /// <param name="output">The zero-based buffer index; defaults to the only buffer of a PDF.</param>
+    /// <returns>
+    /// An owner whose <see cref="IMemoryOwner{T}.Memory"/> is exactly the length of the buffer.
+    /// Dispose it to return the memory to the pool, and do not touch the memory afterwards.
+    /// </returns>
+    public unsafe IMemoryOwner<byte> RentOutput(int output = 0)
+    {
+        var content = GetOutputSpan(output);
+        var owner = new PooledBuffer(content.Length);
+        content.CopyTo(owner.Span);
+        KeepAlive();
+        return owner;
+    }
+
+    /// <summary>
+    /// Copies an output buffer into a newly allocated array. Prefer <see cref="GetOutputSpan"/>,
+    /// <see cref="WriteOutputToFile"/> or <see cref="RentOutput"/> when the copy can be avoided.
+    /// </summary>
+    /// <param name="output">The zero-based buffer index; defaults to the only buffer of a PDF.</param>
+    public unsafe byte[] GetOutputBytes(int output = 0)
+    {
+        var bytes = GetOutputSpan(output).ToArray();
+        KeepAlive();
+        return bytes;
+    }
+
+    private static SafeFileHandle OpenFile(string path, long length, FileOptions options) =>
+        File.OpenHandle(
+            path,
+            FileMode.Create,
+            FileAccess.Write,
+            // A concurrent reader is not locked out, matching File.WriteAllBytes.
+            FileShare.Read,
+            options,
+            preallocationSize: length);
+
+    /// <summary>
+    /// Wraps an output buffer in a <see cref="MemoryManager{T}"/> so that the asynchronous overloads,
+    /// which cannot be declared in an unsafe context, can pass the native memory around as
+    /// <see cref="Memory{T}"/>.
+    /// </summary>
+    private unsafe NativeBufferMemoryManager CreateBufferManager(int output)
+    {
+        var buffer = GetBuffer(output);
+        return new NativeBufferMemoryManager(this, buffer.ptr, ToLength(buffer.len));
+    }
+
+    private unsafe CsBindgen.Buffer GetBuffer(int output)
+    {
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+
+        if ((uint)output >= (uint)_outputCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(output),
+                output,
+                $"The document has {_outputCount} output buffer(s).");
+        }
+
+        return _native.buffers[output];
+    }
+
+    /// <summary>
+    /// Narrows a native buffer length to the <see cref="int"/> the span-based members are limited to.
+    /// A bare <see cref="OverflowException"/> would say nothing about how to proceed.
+    /// </summary>
+    private static int ToLength(nuint length)
+    {
+        if (length > int.MaxValue)
+        {
+            throw new NotSupportedException(
+                $"The output buffer is {length} bytes. Buffers larger than {int.MaxValue} bytes can only be read through OpenOutputStream.");
+        }
+
+        return (int)length;
+    }
+
+    /// <summary>
+    /// Keeps the document reachable until the native buffer has actually been read. Without this the
+    /// collector may consider the document dead right after <see cref="GetBuffer"/> returned and run
+    /// the finalizer, freeing the memory that is still being read from.
+    /// </summary>
+    private void KeepAlive() => GC.KeepAlive(this);
+
+    /// <summary>Releases the native memory held by this document.</summary>
+    public void Dispose()
+    {
+        Free();
+        GC.SuppressFinalize(this);
+    }
+
+    ~TypstDocument()
+    {
+        Free();
+    }
+
+    private unsafe void Free()
+    {
+        // Exchange rather than a plain bool check: a double free corrupts the native heap, which is a
+        // far worse outcome than the torn reads the rest of the type tolerates.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        CsBindgen.NativeMethods.free_compile_result(_native);
+        _native = default;
+        if (_nativeByteCount > 0)
+        {
+            GC.RemoveMemoryPressure(_nativeByteCount);
+        }
+    }
+
+    /// <summary>
+    /// A read-only stream over one output buffer that holds its document alive. Handing out a bare
+    /// <see cref="UnmanagedMemoryStream"/> would let the document be finalized, and its memory freed,
+    /// while the stream was still being read.
+    /// </summary>
+    private sealed unsafe class OutputStream : UnmanagedMemoryStream
+    {
+        private readonly TypstDocument _owner;
+
+        internal OutputStream(TypstDocument owner, byte* pointer, long length)
+            : base(pointer, length, length, FileAccess.Read)
+        {
+            _owner = owner;
+        }
+
+        // Only the byte-array reads are overridden. Every other read path on Stream and
+        // UnmanagedMemoryStream, span and async alike, ends up calling one of these two, so this
+        // covers them all. Overriding Read(Span) as well would recurse: the UnmanagedMemoryStream
+        // override delegates to Stream.Read(Span) for any derived type, and that implementation
+        // calls back into Read(byte[]).
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ObjectDisposedException.ThrowIf(_owner.IsDisposed, _owner);
+            int read = base.Read(buffer, offset, count);
+            GC.KeepAlive(_owner);
+            return read;
+        }
+
+        public override int ReadByte()
+        {
+            ObjectDisposedException.ThrowIf(_owner.IsDisposed, _owner);
+            int value = base.ReadByte();
+            GC.KeepAlive(_owner);
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Rebase of this branch onto `develop` after #32 and #33.

**The merge resolution is yours.** I started from `61fa191` on `add-more-ergonomic-methods`, which already reconciles this work with the ergonomic API, and applied the two #33 renames on top: `Warning.message` → `message_ptr`/`message_len` and `CompileResult.error` → `error_ptr`/`error_len`, decoded with `Encoding.UTF8.GetString(ReadOnlySpan<byte>)` since `string_to_raw` no longer NUL-terminates. `Bindings.g.cs` and `src/typst_core/` are untouched.

### What is new

`CompileToDocument()` returns a disposable `TypstDocument` that owns the native `CompileResult` and exposes the output where Typst allocated it: `GetOutputSpan`, `OpenOutputStream`, `CopyOutputTo(Async)`, `WriteOutputToFile(Async)`, `RentOutput`, `GetOutputBytes`. That is the only zero-copy tier; `PdfResult`/`SvgResult`/`PngResult` still copy, deliberately.

Streams from `OpenOutputStream()` hold a reference to their document and throw once it is disposed, so passing one to an SDK is safe. Spans from `GetOutputSpan()` do not, and are scope-bound.

A document is a list of output buffers rather than pages: PDF export produces one buffer for the whole document, PNG and SVG one per page.

### Scope is smaller than before

I dropped `CompileToFile`/`CompileToFileAsync`/`CompileToStream`/`CompileToStreamAsync` and rewired the methods you already have instead, so this adds no competing names. `Compile()`, `Compile(outputFile, format)`, `CompileSvg()` and `CompilePng()` keep their signatures and behaviour; writing to disk and rendering SVG simply stop materialising the document on the managed heap.

### One deliberate API break

This changes four return types: `CompilePdf(Stream)`, `CompilePdfAsync(Stream)`, `CompilePdf(string outputFile)` and `CompilePdfAsync(string outputFile)` return `IReadOnlyList<string>` (the warnings) instead of `PdfResult`.

`PdfResult` holds a `byte[]`, so anything returning it must materialise the whole document. In `61fa191` that shows up as `CompilePdf(Stream)` streaming to the destination and then calling `GetOutputBytes(0)` anyway for the return value, which is the copy the overload exists to avoid. Nothing here has shipped, so changing the return type seemed better than a method whose name promises streaming and whose signature forbids it. `CompilePdf()` still gives you the bytes.

If you would rather keep the signatures, it is a contained revert: put the four bodies back to `CompilePdf(pdfStandards)` plus a write, and everything else here still applies.

### Two correctness fixes over the original

- `GC.Add/RemoveMemoryPressure` guarded with `> 0`. They throw on `0`, and `AddMemoryPressure` ran after the document took ownership with the finalizer already armed, so a zero-buffer result was freed twice.
- `CompileToDocument` frees in a `catch`, not an unconditional `finally`, which would hand back a document over freed memory.

### Testing

39/39 on linux-x64 (20 tests new here), against `libtypst_core.so` rebuilt from this branch in `rust:1.92` and run under `dotnet/sdk:10.0`. `develop` is 19/19 on the same setup. Windows, macOS and the packaged-runtime matrix are left to CI, as I have no Rust toolchain on Windows.

Note for anyone testing locally: #33 grew `CompileResult` from 40 to 48 bytes and `Warning` from 8 to 16, so running current managed code against the published 0.15.1 native library is an ABI mismatch rather than a couple of cosmetic failures. The native side has to be rebuilt.
