### PR TITLE
feat: resolve packages from the configured directory only

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,27 @@ var result = compiler.Compile(format: "pdf", pdfStandards: new[] { "a-2b", "v-1.
 await File.WriteAllBytesAsync("archival.pdf", result.Buffers[0]);
 ```
 
+### Packages
+
+`packagePath` points the compiler at a directory of Typst packages, laid out as
+`<namespace>/<name>/<version>` just like the machine-wide package directory. It is searched first,
+and anything not found there still falls back to the machine-wide directories and, for `@preview`,
+to a download from Typst Universe.
+
+Pass `includeSystemPackages: false` to drop those fallbacks. Packages then resolve from
+`packagePath` alone, an import that is not vendored there fails with `package not found` instead of
+being fetched, and compilation never touches the network:
+
+```csharp
+var compiler = TypstCompiler.FromFile(
+    "label.typ",
+    packagePath: Path.Combine(AppContext.BaseDirectory, "TypstPackages"),
+    includeSystemPackages: false);
+```
+
+This is what an application that ships its packages alongside its binaries wants, and it keeps
+builds reproducible: whatever is deployed is exactly what gets compiled.
+
 You can easily use this inside of an ASP.Net Server (just ensure you lazy load and cache the TypstCompiler to reduce from 40ms to around 3ms for a normal compile).
 
 ## Prerequisites

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,4 +2,5 @@
 
 ## [Unreleased]
 ### Added
+- Added `includeSystemPackages` to `TypstCompiler`. Setting it to `false` resolves packages from `packagePath` only, so an import that is not vendored there fails instead of being downloaded from Typst Universe and compilation stays off the network.
 - Added support for compiling Typst documents with multiple PDF standards simultaneously (e.g. `v-1.7`, `a-2b`, etc.) by exposing a `pdfStandards` parameter in the `TypstCompiler.Compile` API, leveraging the underlying `typst-pdf` crate updates in Typst 0.15.

--- a/src/typst_core/src/lib.rs
+++ b/src/typst_core/src/lib.rs
@@ -60,6 +60,7 @@ pub extern "C" fn create_compiler(
     package_path: *const c_char,
     sys_inputs: *const c_char,
     ignore_system_fonts: bool,
+    ignore_system_packages: bool,
 ) -> *mut Compiler {
     let root_str = if root.is_null() {
         "."
@@ -126,6 +127,7 @@ pub extern "C" fn create_compiler(
         input_path_buf,
         input_content,
         !ignore_system_fonts,
+        !ignore_system_packages,
     ) {
         Ok(world) => Box::into_raw(Box::new(Compiler(world))),
         Err(_) => ptr::null_mut(),

--- a/src/typst_core/src/world.rs
+++ b/src/typst_core/src/world.rs
@@ -72,6 +72,7 @@ impl SystemWorld {
         input_path: Option<PathBuf>,
         input_content: Option<String>,
         include_system_fonts: bool,
+        include_system_packages: bool,
     ) -> StrResult<Self> {
         let mut fonts = typst_kit::fonts::FontStore::new();
 
@@ -113,6 +114,24 @@ impl SystemWorld {
 
         let book = fonts.book().clone();
 
+        // Packages are looked up in the configured directory first, then in the
+        // machine-wide data and cache directories, and are finally downloaded from
+        // Typst Universe. Dropping the last two is what a deployment that ships its
+        // packages next to the application needs: `SystemPackages::obtain` only
+        // reaches the registry through a cache directory, so leaving the cache out
+        // keeps resolution on the configured directory and off the network.
+        let package_data = match package_path {
+            Some(path) => Some(FsPackages::new(path)),
+            None if include_system_packages => FsPackages::system_data(),
+            None => None,
+        };
+
+        let package_cache = if include_system_packages {
+            FsPackages::system_cache()
+        } else {
+            None
+        };
+
         Ok(Self {
             root,
             main: main_id,
@@ -126,8 +145,8 @@ impl SystemWorld {
             fonts: Arc::new(fonts),
             slots: Mutex::new(slots),
             packages: SystemPackages::from_parts(
-                package_path.map(FsPackages::new).or_else(FsPackages::system_data),
-                FsPackages::system_cache(),
+                package_data,
+                package_cache,
                 UniversePackages::new(crate::download::downloader()),
             ),
             now: typst_kit::datetime::Time::system(),

--- a/src/typst_core/tests/compile.rs
+++ b/src/typst_core/tests/compile.rs
@@ -17,6 +17,7 @@ fn invalid_single_line_string_produces_an_error() {
         std::ptr::null(),
         sys_inputs.as_ptr(),
         true,
+        true,
     );
     assert!(!compiler.is_null(), "failed to create compiler");
 
@@ -53,6 +54,7 @@ fn invalid_multi_line_string_produces_multiple_errors() {
         0,
         std::ptr::null(),
         sys_inputs.as_ptr(),
+        true,
         true,
     );
     assert!(!compiler.is_null(), "failed to create compiler");

--- a/src/typstsharp.tests/Tests.cs
+++ b/src/typstsharp.tests/Tests.cs
@@ -61,6 +61,73 @@ public class Tests
             .WithMessageMatching(regexMatcher);
     }
 
+    /// <summary>
+    /// An application that ships its packages next to the binary resolves them from that
+    /// folder without the machine-wide package directories or the registry taking part.
+    /// </summary>
+    [Test]
+    public async Task BundledPackageResolvesWithSystemPackagesExcluded()
+    {
+        using var packages = new PackageDirectory();
+        packages.AddPackage("local", "greet", "0.1.0", "#let greet() = [Hello from a bundled package]");
+
+        using var compiler = TypstCompiler.FromSource(
+            """
+            #import "@local/greet:0.1.0": greet
+            #greet()
+            """,
+            packagePath: packages.Path,
+            includeSystemPackages: false);
+
+        var plainText = GetPlainText(compiler.Compile().Buffers[0]);
+
+        await Assert.That(plainText).Contains("Hello from a bundled package");
+    }
+
+    /// <summary>
+    /// `@preview/example:0.1.0` is published on Typst Universe, so this compiles only if the
+    /// registry is reachable. Excluding system packages has to turn it into a hard failure
+    /// rather than a download.
+    /// </summary>
+    [Test]
+    public async Task ExcludingSystemPackagesKeepsTheRegistryOutOfReach()
+    {
+        using var packages = new PackageDirectory();
+
+        await Assert.That(() =>
+            {
+                using var compiler = TypstCompiler.FromSource(
+                    """
+                    #import "@preview/example:0.1.0": *
+                    #add(1, 2)
+                    """,
+                    packagePath: packages.Path,
+                    includeSystemPackages: false);
+                _ = compiler.Compile();
+            }).Throws<InvalidOperationException>()
+            .WithMessageContaining("package not found");
+    }
+
+    /// <summary>
+    /// Without a package path there is nowhere left to look once system packages are excluded,
+    /// so even a package installed on the machine stays invisible.
+    /// </summary>
+    [Test]
+    public async Task ExcludingSystemPackagesWithoutAPackagePathFindsNothing()
+    {
+        await Assert.That(() =>
+            {
+                using var compiler = TypstCompiler.FromSource(
+                    """
+                    #import "@local/greet:0.1.0": greet
+                    #greet()
+                    """,
+                    includeSystemPackages: false);
+                _ = compiler.Compile();
+            }).Throws<InvalidOperationException>()
+            .WithMessageContaining("package not found");
+    }
+
     private static string GetPlainText(byte[] pdf)
     {
         var sb = new StringBuilder();
@@ -74,5 +141,38 @@ public class Tests
         }
 
         return sb.ToString();
+    }
+}
+
+/// <summary>
+/// A throwaway package directory laid out the way Typst expects: one directory level per
+/// namespace, package name and version.
+/// </summary>
+internal sealed class PackageDirectory : IDisposable
+{
+    public PackageDirectory() => Directory.CreateDirectory(Path);
+
+    public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"typstsharp-packages-{Guid.NewGuid():N}");
+
+    public void AddPackage(string @namespace, string name, string version, string entrypointSource)
+    {
+        var directory = System.IO.Path.Combine(Path, @namespace, name, version);
+        Directory.CreateDirectory(directory);
+
+        File.WriteAllText(System.IO.Path.Combine(directory, "typst.toml"), $"""
+            [package]
+            name = "{name}"
+            version = "{version}"
+            entrypoint = "lib.typ"
+            """);
+        File.WriteAllText(System.IO.Path.Combine(directory, "lib.typ"), entrypointSource);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(Path))
+        {
+            Directory.Delete(Path, recursive: true);
+        }
     }
 }

--- a/src/typstsharp/Bindings.g.cs
+++ b/src/typstsharp/Bindings.g.cs
@@ -19,7 +19,7 @@ namespace CsBindgen
 
 
         [DllImport(__DllName, EntryPoint = "create_compiler", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern Compiler* create_compiler(byte* root, byte* input_path, byte* input_source, byte** font_paths, nuint font_paths_len, byte* package_path, byte* sys_inputs, [MarshalAs(UnmanagedType.U1)] bool ignore_system_fonts);
+        internal static extern Compiler* create_compiler(byte* root, byte* input_path, byte* input_source, byte** font_paths, nuint font_paths_len, byte* package_path, byte* sys_inputs, [MarshalAs(UnmanagedType.U1)] bool ignore_system_fonts, [MarshalAs(UnmanagedType.U1)] bool ignore_system_packages);
 
         [DllImport(__DllName, EntryPoint = "free_compiler", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         internal static extern void free_compiler(Compiler* compiler);

--- a/src/typstsharp/TypstCompiler.cs
+++ b/src/typstsharp/TypstCompiler.cs
@@ -25,9 +25,16 @@ public unsafe class TypstCompiler : IDisposable
     /// <param name="inputPath">The path to the Typst source file to compile.</param>
     /// <param name="fonts">Font settings, including system fonts and custom font paths.</param>
     /// <param name="sysInputs">Initial system inputs (legacy, prefer SetSysInputs).</param>
+    /// <param name="root">Root directory.</param>
+    /// <param name="packagePath">Directory that packages are resolved from, in place of the machine-wide package directory.</param>
+    /// <param name="includeSystemPackages">
+    /// Whether the machine-wide package directories and the Typst Universe registry may be used.
+    /// Pass <c>false</c> together with <paramref name="packagePath"/> to resolve packages only from
+    /// that directory, which keeps compilation off the network.
+    /// </param>
     /// <exception cref="Exception">Thrown when the Typst compiler fails to initialize.</exception>
-    public TypstCompiler(string inputPath, Fonts? fonts = null, Dictionary<string, string>? sysInputs = null, string? root = null, string? packagePath = null)
-        : this(inputPath, null, fonts, sysInputs, root, packagePath)
+    public TypstCompiler(string inputPath, Fonts? fonts = null, Dictionary<string, string>? sysInputs = null, string? root = null, string? packagePath = null, bool includeSystemPackages = true)
+        : this(inputPath, null, fonts, sysInputs, root, packagePath, includeSystemPackages)
     {
     }
 
@@ -38,10 +45,16 @@ public unsafe class TypstCompiler : IDisposable
     /// <param name="fonts">Font settings.</param>
     /// <param name="sysInputs">System inputs.</param>
     /// <param name="root">Root directory.</param>
+    /// <param name="packagePath">Directory that packages are resolved from, in place of the machine-wide package directory.</param>
+    /// <param name="includeSystemPackages">
+    /// Whether the machine-wide package directories and the Typst Universe registry may be used.
+    /// Pass <c>false</c> together with <paramref name="packagePath"/> to resolve packages only from
+    /// that directory, which keeps compilation off the network.
+    /// </param>
     /// <returns>A new <see cref="TypstCompiler"/> instance.</returns>
-    public static TypstCompiler FromSource(string source, Fonts? fonts = null, Dictionary<string, string>? sysInputs = null, string? root = null, string? packagePath = null)
+    public static TypstCompiler FromSource(string source, Fonts? fonts = null, Dictionary<string, string>? sysInputs = null, string? root = null, string? packagePath = null, bool includeSystemPackages = true)
     {
-        return new TypstCompiler(null, source, fonts, sysInputs, root, packagePath);
+        return new TypstCompiler(null, source, fonts, sysInputs, root, packagePath, includeSystemPackages);
     }
 
     /// <summary>
@@ -51,19 +64,26 @@ public unsafe class TypstCompiler : IDisposable
     /// <param name="fonts">Font settings.</param>
     /// <param name="sysInputs">System inputs.</param>
     /// <param name="root">Root directory.</param>
+    /// <param name="packagePath">Directory that packages are resolved from, in place of the machine-wide package directory.</param>
+    /// <param name="includeSystemPackages">
+    /// Whether the machine-wide package directories and the Typst Universe registry may be used.
+    /// Pass <c>false</c> together with <paramref name="packagePath"/> to resolve packages only from
+    /// that directory, which keeps compilation off the network.
+    /// </param>
     /// <returns>A new <see cref="TypstCompiler"/> instance.</returns>
-    public static TypstCompiler FromFile(string path, Fonts? fonts = null, Dictionary<string, string>? sysInputs = null, string? root = null, string? packagePath = null)
+    public static TypstCompiler FromFile(string path, Fonts? fonts = null, Dictionary<string, string>? sysInputs = null, string? root = null, string? packagePath = null, bool includeSystemPackages = true)
     {
-        return new TypstCompiler(path, null, fonts, sysInputs, root, packagePath);
+        return new TypstCompiler(path, null, fonts, sysInputs, root, packagePath, includeSystemPackages);
     }
 
     
 
-    private TypstCompiler(string? inputPath, string? inputSource, Fonts? fonts, Dictionary<string, string>? sysInputs, string? root, string? packagePath = null)
+    private TypstCompiler(string? inputPath, string? inputSource, Fonts? fonts, Dictionary<string, string>? sysInputs, string? root, string? packagePath = null, bool includeSystemPackages = true)
     {
         fonts ??= new Fonts();
         var fontPaths = fonts.FontPaths ?? [];
         bool ignoreSystemFonts = !fonts.IncludeSystemFonts;
+        bool ignoreSystemPackages = !includeSystemPackages;
 
         var inputPathPtr = inputPath != null ? Marshal.StringToCoTaskMemUTF8(inputPath) : IntPtr.Zero;
         var inputSourcePtr = inputSource != null ? Marshal.StringToCoTaskMemUTF8(inputSource) : IntPtr.Zero;
@@ -99,7 +119,8 @@ public unsafe class TypstCompiler : IDisposable
                     (nuint)fontPathsList.Count, 
                     (byte*)packagePathPtr,
                     (byte*)sysInputsPtr, 
-                    ignoreSystemFonts);
+                    ignoreSystemFonts,
+                    ignoreSystemPackages);
             }
 
             if (_compiler == null)


### PR DESCRIPTION
`packagePath` is only the first of three package sources. `SystemWorld::new` builds:

```rust
SystemPackages::from_parts(
    package_path.map(FsPackages::new).or_else(FsPackages::system_data),
    FsPackages::system_cache(),
    UniversePackages::new(crate::download::downloader()),
)
```

so an import that is not present under `packagePath` falls through to the machine-wide package directory, then to the package cache, and is finally downloaded from Typst Universe. Nothing in the managed API can turn that off.

For an application that deploys its packages next to its binaries, that fallback chain causes three problems: compilation reaches the network from a host that may not be allowed to, the output depends on whatever happens to sit in the machine cache, and a vendoring mistake stays invisible because the fallback quietly repairs it.

`includeSystemPackages: false` drops the last two sources:

```csharp
using var compiler = TypstCompiler.FromFile(
    "label.typ",
    packagePath: Path.Combine(AppContext.BaseDirectory, "TypstPackages"),
    includeSystemPackages: false);
```

Packages then resolve from `packagePath` alone, and an import that is not vendored there fails with `package not found` instead of being fetched.

### Notes on the design

`typst-kit` already models this. `SystemPackages::from_parts` takes an `Option<FsPackages>` for both the data and the cache directory, and `obtain` only reaches the registry through a configured cache. Passing `None` for the cache therefore removes the cache and the download in one step, so no patched resolver or custom registry is needed; the flag just stops filling in the system defaults.

The parameter is additive and defaults to `true`, so existing callers keep the current three-tier behaviour. At the FFI boundary it is `ignore_system_packages`, matching the existing `ignore_system_fonts`.

Three tests cover it: a package resolved from a temporary `packagePath`, an `@preview` import that has to fail rather than download, and the case where system packages are excluded without a `packagePath` at all.
