### PR TITLE
fix: pass Typst source across the FFI boundary with an explicit length

### DIFF
--- a/src/typst_core/src/lib.rs
+++ b/src/typst_core/src/lib.rs
@@ -57,7 +57,8 @@ impl Default for CompileResult {
 pub extern "C" fn create_compiler(
     root: *const c_char,
     input_path: *const c_char,
-    input_source: *const c_char,
+    input_source: *const u8,
+    input_source_len: usize,
     font_paths: *const *const c_char,
     font_paths_len: usize,
     package_path: *const c_char,
@@ -87,11 +88,16 @@ pub extern "C" fn create_compiler(
         None
     };
 
-    let input_content = if !input_source.is_null() {
-        let s = unsafe { CStr::from_ptr(input_source).to_str().unwrap_or("") };
-        Some(s.to_string())
-    } else {
+    // The source is taken as an explicit (pointer, length) pair rather than a C
+    // string. A Typst document may legitimately contain NUL bytes, and reading it
+    // as a C string would silently cut the document off at the first one. A null
+    // pointer means "no in-memory source", which is distinct from a zero length,
+    // which means an empty document.
+    let input_content = if input_source.is_null() {
         None
+    } else {
+        let bytes = unsafe { std::slice::from_raw_parts(input_source, input_source_len) };
+        Some(String::from_utf8_lossy(bytes).into_owned())
     };
 
     let sys_inputs_str = unsafe { CStr::from_ptr(sys_inputs).to_str().unwrap_or("{}") };

--- a/src/typst_core/tests/compile.rs
+++ b/src/typst_core/tests/compile.rs
@@ -1,17 +1,18 @@
 use std::ffi::{c_char, CString};
 
-use typst_core::{compile, create_compiler, free_compile_result, free_compiler};
+use typst_core::{Compiler, compile, create_compiler, free_compile_result, free_compiler};
 
-#[test]
-fn invalid_single_line_string_produces_an_error() {
+/// Creates a compiler over an in-memory document. The source is handed over as
+/// raw bytes, so a test can feed content that a C string could not carry.
+fn compiler_for(source: &[u8]) -> *mut Compiler {
     let root = CString::new(".").unwrap();
-    let source = CString::new("This is not a valid document: # what?").unwrap();
     let sys_inputs = CString::new("{}").unwrap();
 
     let compiler = create_compiler(
         root.as_ptr(),
         std::ptr::null(),
         source.as_ptr(),
+        source.len(),
         std::ptr::null::<*const c_char>(),
         0,
         std::ptr::null(),
@@ -20,18 +21,34 @@ fn invalid_single_line_string_produces_an_error() {
         true,
     );
     assert!(!compiler.is_null(), "failed to create compiler");
+    compiler
+}
+
+/// Compiles the document and returns the error message it produced.
+fn compile_expecting_error(source: &[u8]) -> String {
+    let compiler = compiler_for(source);
 
     let result = compile(compiler, std::ptr::null(), 96.0, std::ptr::null());
-    assert!(!result.error_ptr.is_null(), "invalid document compiled without an error");
+    assert!(
+        !result.error_ptr.is_null(),
+        "invalid document compiled without an error"
+    );
 
     let error = unsafe {
         let slice = std::slice::from_raw_parts(result.error_ptr, result.error_len);
         String::from_utf8_lossy(slice).into_owned()
     };
-    dbg!(&error);
 
     free_compile_result(result);
     free_compiler(compiler);
+
+    dbg!(&error);
+    error
+}
+
+#[test]
+fn invalid_single_line_string_produces_an_error() {
+    let error = compile_expecting_error(b"This is not a valid document: # what?");
 
     assert!(
         error.contains("expected expression"),
@@ -45,34 +62,7 @@ fn invalid_multi_line_string_produces_multiple_errors() {
 
     As a test - this should be able to have a second error, as you can't use dollars here: $50"##;
 
-    let root = CString::new(".").unwrap();
-    let source = CString::new(raw_source).unwrap();
-    let sys_inputs = CString::new("{}").unwrap();
-
-    let compiler = create_compiler(
-        root.as_ptr(),
-        std::ptr::null(),
-        source.as_ptr(),
-        std::ptr::null::<*const c_char>(),
-        0,
-        std::ptr::null(),
-        sys_inputs.as_ptr(),
-        true,
-        true,
-    );
-    assert!(!compiler.is_null(), "failed to create compiler");
-
-    let result = compile(compiler, std::ptr::null(), 96.0, std::ptr::null());
-    assert!(!result.error_ptr.is_null(), "invalid document compiled without an error");
-
-    let error = unsafe {
-        let slice = std::slice::from_raw_parts(result.error_ptr, result.error_len);
-        String::from_utf8_lossy(slice).into_owned()
-    };
-    dbg!(&error);
-
-    free_compile_result(result);
-    free_compiler(compiler);
+    let error = compile_expecting_error(raw_source.as_bytes());
 
     assert!(
         error.contains("expected expression"),
@@ -82,5 +72,18 @@ fn invalid_multi_line_string_produces_multiple_errors() {
     assert!(
         error.contains("unclosed delimiter"),
         "unexpected compiler error: {error}"
+    );
+}
+
+#[test]
+fn source_after_a_nul_byte_is_still_compiled() {
+    // Reading the source as a C string stopped at the NUL, so everything after it
+    // was dropped and this document compiled clean. The invalid tail is what
+    // proves the whole source made it across.
+    let error = compile_expecting_error(b"Valid start\0\n\nAnd then: # what?");
+
+    assert!(
+        error.contains("expected expression"),
+        "source was truncated at the NUL byte: {error}"
     );
 }

--- a/src/typstsharp.tests/Tests.cs
+++ b/src/typstsharp.tests/Tests.cs
@@ -245,6 +245,16 @@ public class Tests
     }
 
     [Test]
+    public async Task SourceAfterNullByteIsNotTruncated()
+    {
+        // The source used to cross the boundary as a C string, so everything from
+        // the NUL onwards was dropped and only the first heading was rendered.
+        using var compiler = TypstCompiler.FromSource("= Before\0\n\n= After");
+        var plainText = GetPlainText(compiler.CompilePdf());
+        await Assert.That(plainText).Contains("After");
+    }
+
+    [Test]
     public async Task InvalidPdfStandardThrowsException()
     {
         await Assert.That(() =>

--- a/src/typstsharp/Bindings.g.cs
+++ b/src/typstsharp/Bindings.g.cs
@@ -19,7 +19,7 @@ namespace CsBindgen
 
 
         [DllImport(__DllName, EntryPoint = "create_compiler", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern Compiler* create_compiler(byte* root, byte* input_path, byte* input_source, byte** font_paths, nuint font_paths_len, byte* package_path, byte* sys_inputs, [MarshalAs(UnmanagedType.U1)] bool ignore_system_fonts, [MarshalAs(UnmanagedType.U1)] bool ignore_system_packages);
+        internal static extern Compiler* create_compiler(byte* root, byte* input_path, byte* input_source, nuint input_source_len, byte** font_paths, nuint font_paths_len, byte* package_path, byte* sys_inputs, [MarshalAs(UnmanagedType.U1)] bool ignore_system_fonts, [MarshalAs(UnmanagedType.U1)] bool ignore_system_packages);
 
         [DllImport(__DllName, EntryPoint = "free_compiler", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         internal static extern void free_compiler(Compiler* compiler);

--- a/src/typstsharp/TypstCompiler.cs
+++ b/src/typstsharp/TypstCompiler.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -235,8 +236,22 @@ public class TypstCompiler : IDisposable
         }
 
         var inputPathPtr = inputPath != null ? Marshal.StringToCoTaskMemUTF8(inputPath) : IntPtr.Zero;
-        var inputSourcePtr = inputSource != null ? Marshal.StringToCoTaskMemUTF8(inputSource) : IntPtr.Zero;
-        
+
+        // The source goes over as raw UTF-8 bytes with an explicit length. A Typst
+        // document may contain NUL bytes, and a NUL-terminated string would be
+        // silently truncated at the first one.
+        byte[]? inputSourceBytes = null;
+        nuint inputSourceLen = 0;
+        if (inputSource != null)
+        {
+            var encoded = Encoding.UTF8.GetBytes(inputSource);
+            inputSourceLen = (nuint)encoded.Length;
+            // `fixed` over an empty array yields a null pointer, which the native
+            // side reads as "no source at all". A one-byte placeholder keeps an
+            // empty document distinguishable; the length passed stays 0.
+            inputSourceBytes = encoded.Length == 0 ? new byte[1] : encoded;
+        }
+
         IntPtr rootPtr = IntPtr.Zero;
         if (!string.IsNullOrWhiteSpace(root))
         {
@@ -258,16 +273,18 @@ public class TypstCompiler : IDisposable
         try
         {
             fixed (IntPtr* fontPathsRawPtr = fontPathPtrs)
+            fixed (byte* inputSourcePtr = inputSourceBytes)
             {
                 IntPtr* fontPathsPtr = fontPathsList.Count == 0 ? null : fontPathsRawPtr;
                 _compiler = CsBindgen.NativeMethods.create_compiler(
-                    (byte*)rootPtr, 
-                    (byte*)inputPathPtr, 
-                    (byte*)inputSourcePtr, 
-                    (byte**)fontPathsPtr, 
-                    (nuint)fontPathsList.Count, 
+                    (byte*)rootPtr,
+                    (byte*)inputPathPtr,
+                    inputSourcePtr,
+                    inputSourceLen,
+                    (byte**)fontPathsPtr,
+                    (nuint)fontPathsList.Count,
                     (byte*)packagePathPtr,
-                    (byte*)sysInputsPtr, 
+                    (byte*)sysInputsPtr,
                     ignoreSystemFonts,
                     ignoreSystemPackages);
             }
@@ -281,7 +298,6 @@ public class TypstCompiler : IDisposable
         {
             if (rootPtr != IntPtr.Zero) Marshal.FreeCoTaskMem(rootPtr);
             if (inputPathPtr != IntPtr.Zero) Marshal.FreeCoTaskMem(inputPathPtr);
-            if (inputSourcePtr != IntPtr.Zero) Marshal.FreeCoTaskMem(inputSourcePtr);
             foreach (var ptr in fontPathPtrs) Marshal.FreeCoTaskMem(ptr);
             if (packagePathPtr != IntPtr.Zero) Marshal.FreeCoTaskMem(packagePathPtr);
             Marshal.FreeCoTaskMem(sysInputsPtr);


### PR DESCRIPTION
Follows on from #33, which moved the diagnostics onto `(pointer, length)` but left the inbound source as a C string.

`create_compiler` read `input_source` with `CStr::from_ptr`, so a document containing a NUL byte was cut off at the first one. Nothing reported an error: the truncated document compiled cleanly and the caller got back a result that silently omitted everything after the NUL. `Marshal.StringToCoTaskMemUTF8` writes the full bytes, interior NUL included, so the loss happened entirely on the native side.

The source now crosses as a `(pointer, length)` pair. A null pointer still means "no in-memory source", which stays distinct from a zero length meaning an empty document. `fixed` over an empty array yields null, so the managed side routes an empty source through a one-byte placeholder to keep those two apart.

Paths, `sys_inputs` and the format strings stay C strings on purpose. A path cannot contain a NUL on either Windows or POSIX, and JSON carries a NUL as a six-character escape rather than the byte itself, so that transport never sees it. Encoding the difference between "a path" and "arbitrary user text" in the signature seemed worth keeping.

### Tests

- `source_after_a_nul_byte_is_still_compiled` puts a syntax error after the NUL and asserts it is reported. With the truncation restored it fails with "invalid document compiled without an error", which is the bug.
- `SourceAfterNullByteIsNotTruncated` asserts a heading after the NUL is present in the rendered PDF.