### PR TITLE
fix: keep the compiler alive across native calls

### DIFF
--- a/src/typstsharp/TypstCompiler.cs
+++ b/src/typstsharp/TypstCompiler.cs
@@ -304,6 +304,12 @@ public class TypstCompiler : IDisposable
         try
         {
             var native = CsBindgen.NativeMethods.compile(_compiler, (byte*)formatPtr, ppi, (byte*)standardsPtr);
+
+            // The P/Invoke is a preemptive-mode transition, so a collection can run while Typst is
+            // compiling. `this` is dead from the field load above onwards, so without this the
+            // finalizer could free the native world underneath the call that is still using it.
+            GC.KeepAlive(this);
+
             try
             {
                 if (native.error_ptr != null)
@@ -506,6 +512,8 @@ public class TypstCompiler : IDisposable
         try
         {
             var ok = CsBindgen.NativeMethods.set_sys_inputs(_compiler, (byte*)sysInputsPtr);
+            GC.KeepAlive(this);
+
             if (!ok)
             {
                 throw new Exception("Failed to set system inputs");


### PR DESCRIPTION
`TypstCompiler` holds a raw `CsBindgen.Compiler*` (`TypstCompiler.cs:15`) and has a finalizer (`:543`) that routes to `Dispose(false)` → `free_compiler` (`:536`), which is a `Box::from_raw` on the Rust side (`typst_core/src/lib.rs:141-147`), so it really does deallocate the `SystemWorld`.

In `Compile`, the last read of `this` is the `_compiler` field load at `:306`. Nothing after the P/Invoke touches the instance: the two `finally` blocks free `IntPtr`s and call statics. Under tier-1 JIT, R2R or NativeAOT the object is therefore dead at the call's return address and eligible for collection while the call is still in flight. The signature is fully blittable, so the transition is inlined and leaves the thread in preemptive mode, which is exactly the window a collection on another thread needs. Rust holds `&mut *compiler` for the whole compile (`lib.rs:271`), so the finalizer would be freeing a live `&mut`. The `catch_unwind` guard does not help here; a use-after-free is not an unwind.

`SetSysInputs` (`:508`) has the same hazard with a much shorter window.

The static helpers (`:90-230`) are safe by accident: they use `using var`, and the generated `finally` keeps the instance rooted. Plain instance use is not, and that is the shape the repo demonstrates: `src/typstsharp.tests/Tests.cs:13` and `README.md:138` both do `var compiler = TypstCompiler.FromSource(...); compiler.Compile();` with no `using`.

No test: a finalizer race is not deterministically reproducible, and a probabilistic one would just be flaky.

Two things I noticed while in here and did not fix, happy to take either as a follow-up:

- `Dispose(bool)` (`:527-541`) is check-then-act on a non-volatile `_disposed`, so two concurrent `Dispose()` calls can both reach `free_compiler`.
- `Dispose()` racing an in-flight `Compile()` frees the world mid-compile. `GC.KeepAlive` cannot fix that one. A `SafeHandle` with `DangerousAddRef`/`Release` and a critical finalizer would close all three races at once, if you would rather have one change than three.
