### PR TITLE
perf: stop allocating a warnings array for a clean compile

### DIFF
--- a/src/typstsharp.tests/Tests.cs
+++ b/src/typstsharp.tests/Tests.cs
@@ -910,6 +910,26 @@ public class Tests
         await Assert.That(document.Warnings is string[]).IsFalse();
     }
 
+    /// <summary>
+    /// The warning-free case had no coverage. This pins the public contract rather than the
+    /// allocation, so it holds whichever way the empty list is produced: empty, and not a mutable
+    /// array handed out to callers.
+    /// </summary>
+    [Test]
+    public async Task WarningsFromACleanCompileAreEmptyAndStillImmutable()
+    {
+        using var compiler = TypstCompiler.FromSource("= No warnings here");
+        var document = compiler.CompileToDocument();
+
+        await Assert.That(document.Warnings.Count).IsEqualTo(0);
+        await Assert.That(document.Warnings is string[]).IsFalse();
+
+        document.Dispose();
+
+        // Warnings are copied out of native memory eagerly, so they outlive the document.
+        await Assert.That(document.Warnings.Count).IsEqualTo(0);
+    }
+
     private const string TwoPageSource = """
                                          First page
                                          #pagebreak()

--- a/src/typstsharp/TypstDocument.cs
+++ b/src/typstsharp/TypstDocument.cs
@@ -53,7 +53,8 @@ public sealed class TypstDocument : IDisposable
         }
 
         // Warnings are small and are copied eagerly so that they stay usable after disposal.
-        var warnings = new string[warningCount];
+        // A clean compile is the common case, and Array.Empty spares it the only allocation here.
+        var warnings = warningCount == 0 ? Array.Empty<string>() : new string[warningCount];
         for (int i = 0; i < warnings.Length; i++)
         {
             var warning = native.warnings[i];


### PR DESCRIPTION
Every `TypstDocument` allocated `new string[warningCount]` even when the compiler reported no warnings, which is the common case. `Array.Empty<string>()` covers it without allocating.

Scope, stated plainly: this saves **24 bytes per warning-free compile**, and nothing else. `Array.AsReadOnly` has returned the shared empty collection for a zero-length array since .NET 8, so the wrapper it is passed to was already free. Against a compile that takes milliseconds and allocates megabytes of native memory, this is below noise — it is here because it is one line and free, not because it is measurable.

The test covers the warning-free case, which had none. It pins the public contract rather than the allocation, so it passes on `develop` too; it is coverage, not a regression guard.

57/57 pass, clean on net8/9/10.
